### PR TITLE
Add ptp-operator to mirror-operators script

### DIFF
--- a/mirror/mirror-operators.sh
+++ b/mirror/mirror-operators.sh
@@ -33,6 +33,7 @@ OPERATOR_LIST=(
   "kubernetes-nmstate-operator"
   "sriov-fec"
   "metallb-operator"
+  "ptp-operator"
   "cluster-logging")
 
 # build the jq/yq expression to select entry with either name or package in the OPERATOR_LIST


### PR DESCRIPTION
PTP operator is one of the important operator for SNO, it was missing in mirror script